### PR TITLE
Compared performance of pure-Java references vs. Java interop.

### DIFF
--- a/lib/ref/version.rb
+++ b/lib/ref/version.rb
@@ -1,3 +1,3 @@
 module Ref
-  VERSION = '1.0.5'
+  VERSION = '2.0.0.pre1'
 end

--- a/ref_speed_test.rb
+++ b/ref_speed_test.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+
+require 'ref'
+require 'benchmark'
+
+REF_CLASSES = [
+  Ref::SoftReference,
+  Ref::WeakReference
+]
+
+NUM = 500_000
+
+def version
+  if defined? Ref::VERSION
+    Ref::VERSION
+  else
+    gem_dir = Gem::Specification.find_by_name('ref').gem_dir
+    File.open(File.join(gem_dir, 'VERSION'), 'r').read
+  end
+rescue
+  'unknown'
+end
+
+puts "~~~ Ruby version: #{RUBY_VERSION}"
+if defined? JRUBY_VERSION
+  puts "~~~ JRuby version: #{JRUBY_VERSION}"
+else
+  puts "~~~ Ruby engine: #{RUBY_ENGINE}"
+end
+puts "~~~ Gem version: #{version}"
+
+Benchmark.bm do |stats|
+
+  REF_CLASSES.each do |clazz|
+
+    puts "Benchmarking #{clazz}..."
+
+    ref = clazz.new('foo')
+    value = nil
+
+    stats.report do
+      NUM.times { value = ref.object }
+    end
+  end
+end
+
+__END__
+
+~~~ Ruby version: 1.9.3
+~~~ JRuby version: 1.7.18
+~~~ Gem version: 1.0.5
+       user     system      total        real
+Benchmarking Ref::SoftReference...
+   0.270000   0.010000   0.280000 (  0.114000)
+Benchmarking Ref::WeakReference...
+   0.080000   0.000000   0.080000 (  0.029000)
+
+~~~ Ruby version: 1.9.3
+~~~ JRuby version: 1.7.18
+~~~ Gem version: 2.0.0.pre1
+       user     system      total        real
+Benchmarking Ref::SoftReference...
+   1.020000   0.040000   1.060000 (  0.410000)
+Benchmarking Ref::WeakReference...
+   0.200000   0.020000   0.220000 (  0.165000)
+
+~~~ Ruby version: 2.2.0
+~~~ Ruby engine: ruby
+~~~ Gem version: 2.0.0.pre1
+       user     system      total        real
+Benchmarking Ref::SoftReference...
+   0.610000   0.000000   0.610000 (  0.621205)
+Benchmarking Ref::WeakReference...
+   0.120000   0.000000   0.120000 (  0.113426)
+
+~~~ Ruby version: 2.1.0
+~~~ Ruby engine: rbx
+~~~ Gem version: 2.0.0.pre1
+       user     system      total        real
+Benchmarking Ref::SoftReference...
+   1.725505   0.007228   1.732733 (  0.922712)
+Benchmarking Ref::WeakReference...
+   0.167794   0.001500   0.169294 (  0.088065)

--- a/ref_speed_test.rb
+++ b/ref_speed_test.rb
@@ -4,12 +4,12 @@ require 'ref'
 require 'benchmark'
 
 REF_CLASSES = [
-  Ref::SoftReference,
-  Ref::WeakReference
+    Ref::SoftReference,
+    Ref::WeakReference
 ]
 
-NUM = 500_000
-WARM_UPS = 50
+NUM      = 50_000_000
+WARM_UPS = NUM
 
 def jruby?
   defined? JRUBY_VERSION
@@ -40,7 +40,7 @@ Benchmark.bm do |stats|
 
     puts "Benchmarking #{clazz}..."
 
-    ref = clazz.new('foo')
+    ref   = clazz.new('foo')
     value = nil
 
     puts 'Before JVM warm-up...' if jruby?
@@ -65,36 +65,33 @@ $ jruby --server ref_speed_test.rb
 ~~~ Ruby version: 1.9.3
 ~~~ JRuby version: 1.7.18
 ~~~ Gem version: 1.0.5
-user     system      total        real
+       user     system      total        real
 Benchmarking Ref::SoftReference...
-  Before JVM warm-up...
-  0.160000   0.000000   0.160000 (  0.072000)
+Before JVM warm-up...
+   2.210000   0.010000   2.220000 (  1.989000)
 After JVM warm-up...
-  0.150000   0.010000   0.160000 (  0.087000)
+   2.390000   0.010000   2.400000 (  2.339000)
 Benchmarking Ref::WeakReference...
-  Before JVM warm-up...
-  0.050000   0.000000   0.050000 (  0.025000)
+Before JVM warm-up...
+   2.210000   0.000000   2.210000 (  2.208000)
 After JVM warm-up...
-   0.050000   0.000000   0.050000 (  0.033000)
+   2.330000   0.010000   2.340000 (  2.335000)
 
-
-
-$ be jruby --server ref_speed_test.rb
+$ be ruby --server ref_speed_test.rb
 ~~~ Ruby version: 1.9.3
 ~~~ JRuby version: 1.7.18
 ~~~ Gem version: 2.0.0.pre1
        user     system      total        real
 Benchmarking Ref::SoftReference...
 Before JVM warm-up...
-   0.990000   0.020000   1.010000 (  0.521000)
+  17.230000   0.090000  17.320000 ( 16.411000)
 After JVM warm-up...
-   0.390000   0.010000   0.400000 (  0.236000)
+  17.260000   0.050000  17.310000 ( 17.566000)
 Benchmarking Ref::WeakReference...
 Before JVM warm-up...
-   0.200000   0.000000   0.200000 (  0.121000)
+   5.820000   0.010000   5.830000 (  5.865000)
 After JVM warm-up...
-   0.060000   0.000000   0.060000 (  0.059000)
-
+   5.460000   0.000000   5.460000 (  5.525000)
 
 
 $ be ruby ref_speed_test.rb
@@ -103,9 +100,9 @@ $ be ruby ref_speed_test.rb
 ~~~ Gem version: 2.0.0.pre1
        user     system      total        real
 Benchmarking Ref::SoftReference...
-   1.070000   0.000000   1.070000 (  1.066836)
+ 108.620000   0.220000 108.840000 (110.627922)
 Benchmarking Ref::WeakReference...
-   0.160000   0.000000   0.160000 (  0.162876)
+  23.450000   0.050000  23.500000 ( 23.859564)
 
 
 
@@ -115,6 +112,6 @@ $ be ruby ref_speed_test.rb
 ~~~ Gem version: 2.0.0.pre1
        user     system      total        real
 Benchmarking Ref::SoftReference...
-   2.852072   0.012584   2.864656 (  1.673675)
+ 109.086397   0.202284 109.288681 (109.015337)
 Benchmarking Ref::WeakReference...
-   0.287896   0.001336   0.289232 (  0.154698)
+   7.204607   0.011526   7.216133 (  7.070819)


### PR DESCRIPTION
## Performance Comparison -- Do Not Merge

In PR #17 we removed the pure-Java reference classes and replaced them with Ruby wrapper classes. Both implementations wrapped the same classes from `java.lang.ref` so I assumed the performance would be similar. It appears that I was wrong. Based on the speed test in this PR, the original implementation was much faster. Subsequently we should probably revert the change.

If anyone has some time, please verify my tests and findings.

```
~~~ Ruby version: 1.9.3
~~~ JRuby version: 1.7.18
~~~ Gem version: 1.0.5
       user     system      total        real
Benchmarking Ref::SoftReference...
   0.270000   0.010000   0.280000 (  0.114000)
Benchmarking Ref::WeakReference...
   0.080000   0.000000   0.080000 (  0.029000)

~~~ Ruby version: 1.9.3
~~~ JRuby version: 1.7.18
~~~ Gem version: 2.0.0.pre1
       user     system      total        real
Benchmarking Ref::SoftReference...
   1.020000   0.040000   1.060000 (  0.410000)
Benchmarking Ref::WeakReference...
   0.200000   0.020000   0.220000 (  0.165000)
```