### PR TITLE
Avoid Ruby warning by removing an "interesting" whitespace

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: ruby
 dist: trusty
 rvm:
+  - 2.4.1
+  - 2.3.4
   - 2.2.7
   - 2.1.10
   - 2.0.0
   - 1.9.3
-  - ruby-head
+  - jruby-9.1.12.0
   - jruby-1.7.27
+  - ruby-head
   - jruby-head
   - rbx-3.84
 before_install:
@@ -26,6 +29,4 @@ branches:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
-    - rvm: 1.9.3
+    - rvm: rbx-3.84

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 dist: trusty
 rvm:
-  - 2.2.0
-  - 2.1.5
-  - 2.1.4
+  - 2.2.7
+  - 2.1.10
   - 2.0.0
   - 1.9.3
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ rvm:
   - jruby-1.7.27
   - jruby-head
   - rbx-3.84
-
+after_success:
+  - "bundle exec coveralls push"
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-
+dist: trusty
 rvm:
   - 2.2.0
   - 2.1.5
@@ -7,7 +7,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - ruby-head
-  - jruby-1.7.18
+  - jruby-1.7.27
   - jruby-head
   - rbx-3.84
 
@@ -21,6 +21,7 @@ branches:
     - master
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - ruby-head
   - jruby-1.7.18
   - jruby-head
-  - rbx-2
+  - rbx-3.69
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - ruby-head
   - jruby-1.7.18
   - jruby-head
-  - rbx-3
+  - rbx-3.84
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ rvm:
 before_install:
   - gem update --system
   - gem install bundler
-after_success:
-  - "bundle exec coveralls push"
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - ruby-head
   - jruby-1.7.18
   - jruby-head
-  - rbx-3.69
+  - rbx-3
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ rvm:
   - jruby-1.7.27
   - jruby-head
   - rbx-3.84
+before_install:
+  - gem update --system
+  - gem install bundler
 after_success:
   - "bundle exec coveralls push"
 jdk:

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 group :testing do
   gem 'test-unit', '~> 3.0.9'
   gem 'rspec', '~> 3.6'
-  gem 'coveralls', '~> 0.7.3', :require => false
+  gem 'coveralls', '~> 0.8.21', :require => false
 end
 
 group :documentation do

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 group :testing do
   gem 'test-unit', '~> 3.0.9'
-  gem 'rspec', '~> 3.1.0'
+  gem 'rspec', '~> 3.6'
   gem 'coveralls', '~> 0.7.3', :require => false
 end
 

--- a/lib/ref/abstract_reference_key_map.rb
+++ b/lib/ref/abstract_reference_key_map.rb
@@ -142,7 +142,7 @@ module Ref
 
     private
 
-    def ref_key (key)
+    def ref_key(key)
       ref = @references_to_keys_map[key.__id__]
       if ref && ref.object
         ref.referenced_object_id

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
-]
+])
 
 SimpleCov.start do
   project_name 'ref'


### PR DESCRIPTION
This PR wants to fix a Ruby warning emitted:

> parentheses after method name is interpreted as an argument list, not a decomposed argument

This appears when running Sinatra's test suite.

https://api.travis-ci.org/jobs/268657054/log.txt?deansi=true

---

In order to get a green build for this, I went down the rabbit hole and tried to make it green.