### PR TITLE
Ruby 1.9 Compatibility: Add missing require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ rvm:
   - ruby-head
   - jruby-head
   - rbx-3.84
-before_install:
-  - gem update --system
-  - gem install bundler
 jdk:
   - oraclejdk8
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :testing do
   gem 'test-unit', '~> 3.0.9'
   gem 'rspec', '~> 3.6'
   gem 'coveralls', '~> 0.8.21', :require => false
+  gem 'json', '< 2.3', :platforms => [:ruby_19, :jruby], :require => false
 end
 
 group :documentation do

--- a/lib/ref.rb
+++ b/lib/ref.rb
@@ -5,6 +5,7 @@ module Ref
   require 'ref/abstract_reference_key_map'
   require 'ref/reference'
   require 'ref/reference_queue'
+  require 'monitor'
 
   if defined?(Java)
     begin


### PR DESCRIPTION

Fixes a compatibility issue introduced by 96a6d94f942e0dc1178be07d93bf3d1d79a2ed86. Monitor needs to be explicitly required in Ruby 1.9.

Steps to reproduce:

    $ sudo gem install ref -v 2.0.0
    $ irb -r ref

```
/var/lib/gems/1.9.1/gems/ref-2.0.0/lib/ref/soft_reference.rb:26:in `<class:SoftReference>': uninitialized constant Ref::SoftReference::Monitor (NameError)
	from /var/lib/gems/1.9.1/gems/ref-2.0.0/lib/ref/soft_reference.rb:19:in `<module:Ref>'
	from /var/lib/gems/1.9.1/gems/ref-2.0.0/lib/ref/soft_reference.rb:1:in `<top (required)>'
	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
	from /var/lib/gems/1.9.1/gems/ref-2.0.0/lib/ref.rb:19:in `<module:Ref>'
	from /var/lib/gems/1.9.1/gems/ref-2.0.0/lib/ref.rb:1:in `<top (required)>'
	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
	from /usr/lib/ruby/1.9.1/irb/init.rb:281:in `block in load_modules'
	from /usr/lib/ruby/1.9.1/irb/init.rb:279:in `each'
	from /usr/lib/ruby/1.9.1/irb/init.rb:279:in `load_modules'
	from /usr/lib/ruby/1.9.1/irb/init.rb:20:in `setup'
	from /usr/lib/ruby/1.9.1/irb.rb:53:in `start'
	from /usr/bin/irb:12:in `<main>'
```